### PR TITLE
$c->rendered to actually send off the response

### DIFF
--- a/lib/Mojolicious/Plugin/Cache/Action.pm
+++ b/lib/Mojolicious/Plugin/Cache/Action.pm
@@ -49,6 +49,7 @@ sub register {
                 $c->res->headers( $data->{headers} );
                 $c->res->body( $data->{body} );
                 $c->stash( 'from_cache' => 1 );
+                $c->rendered;
             }
         }
     );


### PR DESCRIPTION
Once detected that there is a cached version available, it wasn't sent of straight away, but Mojolious was kept waiting for potential delayed content.

This will fix it.
